### PR TITLE
Changed inlineOrAnchored from falst to true

### DIFF
--- a/src/helpers/render-document-file.js
+++ b/src/helpers/render-document-file.js
@@ -50,7 +50,7 @@ export const buildImage = (docxDocumentInstance, vNode, maximumWidth = null) => 
       vNode,
       {
         type: 'picture',
-        inlineOrAnchored: true,
+        inlineOrAnchored: false,
         relationshipId: documentRelsId,
         ...response,
         maximumWidth: maximumWidth || docxDocumentInstance.availableDocumentSpace,


### PR DESCRIPTION

![Screenshot from 2020-10-19 16-43-32](https://user-images.githubusercontent.com/73118157/96459360-b7697400-122a-11eb-9c80-066fe4f99077.png)
The document which is generated with original repository has problem with images in Libbre Office, but in other software is ok. It's cropped to one string. If you change inlineOrAnchored it works ok.