### PR TITLE
Replace orientation with custom page size

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ full fledged examples can be found under `example/`
 - `htmlString` <[String]> clean html string equivalent of document content.
 - `headerHTMLString` <[String]> clean html string equivalent of header. Defaults to `<p></p>` if header flag is `true`.
 - `documentOptions` <?[Object]>
-  - `orientation` <"portrait"|"landscape"> defines the general orientation of the document. Defaults to portrait.
+  - `pageSize` <?[Object]> Defaults to U.S. letter portrait orientation.
+    - `width` <[Number]> width of the page for all pages in this section in [TWIP]. Defaults to 12240. Maximum 31680. Supports equivalent measurement in [pixel], [cm] or [inch].
+    - `height` <[Number]> height of the page for all pages in this section in [TWIP]. Defaults to 15840. Maximum 31680. Supports equivalent measurement in [pixel], [cm] or [inch].
   - `margins` <?[Object]>
     - `top` <[Number]> distance between the top of the text margins for the main document and the top of the page for all pages in this section in [TWIP]. Defaults to 1440. Supports equivalent measurement in [pixel], [cm] or [inch].
     - `right` <[Number]> distance between the right edge of the page and the right edge of the text extents for this document in [TWIP]. Defaults to 1800. Supports equivalent measurement in [pixel], [cm] or [inch].

--- a/src/docx-document.js
+++ b/src/docx-document.js
@@ -40,7 +40,7 @@ class DocxDocument {
   constructor({
     zip,
     htmlString,
-    orientation,
+    pageSize,
     margins,
     title,
     subject,
@@ -64,14 +64,13 @@ class DocxDocument {
   }) {
     this.zip = zip;
     this.htmlString = htmlString;
-    this.orientation = orientation;
-    this.width = orientation === 'landscape' ? 15840 : 12240;
-    this.height = orientation === 'landscape' ? 12240 : 15840;
+    this.width = pageSize && pageSize.width ? pageSize.width : 12240;
+    this.height = pageSize && pageSize.height ? pageSize.height : 15840;
     this.margins =
       // eslint-disable-next-line no-nested-ternary
       margins && Object.keys(margins).length
         ? margins
-        : orientation === 'landscape'
+        : this.width >= this.height
         ? landscapeMargins
         : portraitMargins;
     this.availableDocumentSpace = this.width - this.margins.left - this.margins.right;

--- a/src/html-to-docx.js
+++ b/src/html-to-docx.js
@@ -22,7 +22,10 @@ const convertHTML = require('html-to-vdom')({
 });
 
 const defaultDocumentOptions = {
-  orientation: 'portrait',
+  pageSize: {
+    width: 12240,
+    height: 15840,
+  },
   margins: {
     top: 1440,
     right: 1800,
@@ -75,32 +78,32 @@ const fixupFontSize = (fontSize) => {
   return normalizedFontSize;
 };
 
-const fixupMargins = (margins) => {
-  let normalizedMargins = {};
-  if (typeof margins === 'object' && margins !== null) {
-    Object.keys(margins).forEach((key) => {
-      if (pixelRegex.test(margins[key])) {
-        const matchedParts = margins[key].match(pixelRegex);
-        normalizedMargins[key] = pixelToTWIP(matchedParts[1]);
-      } else if (cmRegex.test(margins[key])) {
-        const matchedParts = margins[key].match(cmRegex);
-        normalizedMargins[key] = cmToTWIP(matchedParts[1]);
-      } else if (inchRegex.test(margins[key])) {
-        const matchedParts = margins[key].match(inchRegex);
-        normalizedMargins[key] = inchToTWIP(matchedParts[1]);
-      } else if (margins[key]) {
-        normalizedMargins[key] = margins[key];
+const normalizeUnits = (dimensioningObject, defaultDimensionsProperty) => {
+  let normalizedUnitResult = {};
+  if (typeof dimensioningObject === 'object' && dimensioningObject !== null) {
+    Object.keys(dimensioningObject).forEach((key) => {
+      if (pixelRegex.test(dimensioningObject[key])) {
+        const matchedParts = dimensioningObject[key].match(pixelRegex);
+        normalizedUnitResult[key] = pixelToTWIP(matchedParts[1]);
+      } else if (cmRegex.test(dimensioningObject[key])) {
+        const matchedParts = dimensioningObject[key].match(cmRegex);
+        normalizedUnitResult[key] = cmToTWIP(matchedParts[1]);
+      } else if (inchRegex.test(dimensioningObject[key])) {
+        const matchedParts = dimensioningObject[key].match(inchRegex);
+        normalizedUnitResult[key] = inchToTWIP(matchedParts[1]);
+      } else if (dimensioningObject[key]) {
+        normalizedUnitResult[key] = dimensioningObject[key];
       } else {
         // incase value is something like 0
-        normalizedMargins[key] = defaultDocumentOptions.margins[key];
+        normalizedUnitResult[key] = defaultDimensionsProperty[key];
       }
     });
   } else {
     // eslint-disable-next-line no-param-reassign
-    normalizedMargins = null;
+    normalizedUnitResult = null;
   }
 
-  return normalizedMargins;
+  return normalizedUnitResult;
 };
 
 const normalizeDocumentOptions = (documentOptions) => {
@@ -108,8 +111,12 @@ const normalizeDocumentOptions = (documentOptions) => {
   Object.keys(documentOptions).forEach((key) => {
     // eslint-disable-next-line default-case
     switch (key) {
+      case 'pageSize':
       case 'margins':
-        normalizedDocumentOptions.margins = fixupMargins(documentOptions[key]);
+        normalizedDocumentOptions[key] = normalizeUnits(
+          documentOptions[key],
+          defaultDocumentOptions[key]
+        );
         break;
       case 'fontSize':
       case 'complexScriptFontSize':


### PR DESCRIPTION
Enhancement replacing limited U.S. letter size portrait/landscape orientation parameter with more flexible pageSize parameter, per #56 . Supersedes PR #58, as it was easier to raise a new PR to comply with @privateOmega's request to rebase on `develop`.

Per my conventional commit notation, this is a breaking change. I understand @amrita-syn's concern about preserving backward-compatible functionality for an interim minor release but don't have further time to devote to this, so offer this PR as-is.