### PR TITLE
feat(schema): add theme

### DIFF
--- a/src/docx-document.js
+++ b/src/docx-document.js
@@ -5,6 +5,7 @@ import {
   generateCoreXML,
   generateStylesXML,
   generateNumberingXMLTemplate,
+  generateThemeXML,
   documentRelsXML as documentRelsXMLString,
   settingsXML as settingsXMLString,
   webSettingsXML as webSettingsXMLString,
@@ -114,6 +115,7 @@ class DocxDocument {
     this.generateWebSettingsXML = this.generateWebSettingsXML.bind(this);
     this.generateStylesXML = this.generateStylesXML.bind(this);
     this.generateFontTableXML = this.generateFontTableXML.bind(this);
+    this.generateThemeXML = this.generateThemeXML.bind(this);
     this.generateNumberingXML = this.generateNumberingXML.bind(this);
     this.generateRelsXML = this.generateRelsXML.bind(this);
     this.createMediaFile = this.createMediaFile.bind(this);
@@ -291,6 +293,13 @@ class DocxDocument {
     const fontTableXML = create({ encoding: 'UTF-8', standalone: true }, fontTableXMLString);
 
     return fontTableXML.toString({ prettyPrint: true });
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  generateThemeXML() {
+    const themeXml = create({ encoding: 'UTF-8', standalone: true }, generateThemeXML(this.font));
+
+    return themeXml.toString({ prettyPrint: true });
   }
 
   generateNumberingXML() {
@@ -481,6 +490,9 @@ class DocxDocument {
         break;
       case 'footer':
         relationshipType = namespaces.footers;
+        break;
+      case 'theme':
+        relationshipType = namespaces.themes;
         break;
       default:
         break;

--- a/src/helpers/namespaces.js
+++ b/src/helpers/namespaces.js
@@ -23,6 +23,7 @@ const namespaces = {
   styles: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles',
   headers: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/header',
   footers: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer',
+  themes: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme',
   coreProperties: 'http://schemas.openxmlformats.org/package/2006/metadata/core-properties',
   officeDocumentRelation:
     'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument',

--- a/src/html-to-docx.js
+++ b/src/html-to-docx.js
@@ -203,6 +203,16 @@ export function addFilesToContainer(
     docxDocument.footerObjects.push({ footerId, relationshipId, type: docxDocument.footerType });
   }
 
+  docxDocument.createDocumentRelationships(
+    docxDocument.relationshipFilename,
+    'theme',
+    'theme/theme1.xml',
+    'Internal'
+  );
+  zip.folder('word').folder('theme').file('theme1.xml', docxDocument.generateThemeXML(), {
+    createFolders: false,
+  });
+
   zip
     .folder('word')
     .file('document.xml', docxDocument.generateDocumentXML(), {

--- a/src/schemas/content-types.js
+++ b/src/schemas/content-types.js
@@ -11,6 +11,7 @@ const contentTypesXML = `
         <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
         <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
         <Override PartName="/word/numbering.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml"/>
+        <Override PartName="/word/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>
         <Override PartName="/word/fontTable.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.fontTable+xml"/>
         <Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>
         <Override PartName="/word/settings.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml"/>

--- a/src/schemas/index.js
+++ b/src/schemas/index.js
@@ -5,6 +5,7 @@ export { default as relsXML } from './rels';
 export { default as generateNumberingXMLTemplate } from './numbering';
 export { default as generateStylesXML } from './styles';
 export { default as fontTableXML } from './font-table';
+export { default as generateThemeXML } from './theme';
 export { default as settingsXML } from './settings';
 export { default as webSettingsXML } from './web-settings';
 export { default as genericRelsXML } from './generic-rels';

--- a/src/schemas/theme.js
+++ b/src/schemas/theme.js
@@ -1,0 +1,197 @@
+const generateThemeXML = (font = 'Times New Roman') => `
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+    <a:theme xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" name="Office Theme">
+    <a:themeElements>
+      <a:clrScheme name="Office">
+        <a:dk1>
+          <a:sysClr val="windowText" lastClr="000000"/>
+        </a:dk1>
+        <a:lt1>
+          <a:sysClr val="window" lastClr="FFFFFF"/>
+        </a:lt1>
+        <a:dk2>
+          <a:srgbClr val="44546A"/>
+        </a:dk2>
+        <a:lt2>
+          <a:srgbClr val="E7E6E6"/>
+        </a:lt2>
+        <a:accent1>
+          <a:srgbClr val="4472C4"/>
+        </a:accent1>
+        <a:accent2>
+          <a:srgbClr val="ED7D31"/>
+        </a:accent2>
+        <a:accent3>
+          <a:srgbClr val="A5A5A5"/>
+        </a:accent3>
+        <a:accent4>
+          <a:srgbClr val="FFC000"/>
+        </a:accent4>
+        <a:accent5>
+          <a:srgbClr val="5B9BD5"/>
+        </a:accent5>
+        <a:accent6>
+          <a:srgbClr val="70AD47"/>
+        </a:accent6>
+        <a:hlink>
+          <a:srgbClr val="0563C1"/>
+        </a:hlink>
+        <a:folHlink>
+          <a:srgbClr val="954F72"/>
+        </a:folHlink>
+      </a:clrScheme>
+      <a:fontScheme name="Office">
+        <a:majorFont>
+          <a:latin typeface="${font}"/>
+          <a:ea typeface="${font}"/>
+          <a:cs typeface=""/>
+        </a:majorFont>
+        <a:minorFont>
+          <a:latin typeface="${font}"/>
+          <a:ea typeface="${font}"/>
+          <a:cs typeface=""/>
+        </a:minorFont>
+      </a:fontScheme>
+      <a:fmtScheme name="Office">
+        <a:fillStyleLst>
+          <a:solidFill>
+            <a:schemeClr val="phClr"/>
+          </a:solidFill>
+          <a:gradFill rotWithShape="1">
+            <a:gsLst>
+              <a:gs pos="0">
+                <a:schemeClr val="phClr">
+                  <a:lumMod val="110000"/>
+                  <a:satMod val="105000"/>
+                  <a:tint val="67000"/>
+                </a:schemeClr>
+              </a:gs>
+              <a:gs pos="50000">
+                <a:schemeClr val="phClr">
+                  <a:lumMod val="105000"/>
+                  <a:satMod val="103000"/>
+                  <a:tint val="73000"/>
+                </a:schemeClr>
+              </a:gs>
+              <a:gs pos="100000">
+                <a:schemeClr val="phClr">
+                  <a:lumMod val="105000"/>
+                  <a:satMod val="109000"/>
+                  <a:tint val="81000"/>
+                </a:schemeClr>
+              </a:gs>
+            </a:gsLst>
+            <a:lin ang="5400000" scaled="0"/>
+          </a:gradFill>
+          <a:gradFill rotWithShape="1">
+            <a:gsLst>
+              <a:gs pos="0">
+                <a:schemeClr val="phClr">
+                  <a:satMod val="103000"/>
+                  <a:lumMod val="102000"/>
+                  <a:tint val="94000"/>
+                </a:schemeClr>
+              </a:gs>
+              <a:gs pos="50000">
+                <a:schemeClr val="phClr">
+                  <a:satMod val="110000"/>
+                  <a:lumMod val="100000"/>
+                  <a:shade val="100000"/>
+                </a:schemeClr>
+              </a:gs>
+              <a:gs pos="100000">
+                <a:schemeClr val="phClr">
+                  <a:lumMod val="99000"/>
+                  <a:satMod val="120000"/>
+                  <a:shade val="78000"/>
+                </a:schemeClr>
+              </a:gs>
+            </a:gsLst>
+            <a:lin ang="5400000" scaled="0"/>
+          </a:gradFill>
+        </a:fillStyleLst>
+        <a:lnStyleLst>
+          <a:ln w="6350" cap="flat" cmpd="sng" algn="ctr">
+            <a:solidFill>
+              <a:schemeClr val="phClr"/>
+            </a:solidFill>
+            <a:prstDash val="solid"/>
+            <a:miter lim="800000"/>
+          </a:ln>
+          <a:ln w="12700" cap="flat" cmpd="sng" algn="ctr">
+            <a:solidFill>
+              <a:schemeClr val="phClr"/>
+            </a:solidFill>
+            <a:prstDash val="solid"/>
+            <a:miter lim="800000"/>
+          </a:ln>
+          <a:ln w="19050" cap="flat" cmpd="sng" algn="ctr">
+            <a:solidFill>
+              <a:schemeClr val="phClr"/>
+            </a:solidFill>
+            <a:prstDash val="solid"/>
+            <a:miter lim="800000"/>
+          </a:ln>
+        </a:lnStyleLst>
+        <a:effectStyleLst>
+          <a:effectStyle>
+            <a:effectLst/>
+          </a:effectStyle>
+          <a:effectStyle>
+            <a:effectLst/>
+          </a:effectStyle>
+          <a:effectStyle>
+            <a:effectLst>
+              <a:outerShdw blurRad="57150" dist="19050" dir="5400000" algn="ctr" rotWithShape="0">
+                <a:srgbClr val="000000">
+                  <a:alpha val="63000"/>
+                </a:srgbClr>
+              </a:outerShdw>
+            </a:effectLst>
+          </a:effectStyle>
+        </a:effectStyleLst>
+        <a:bgFillStyleLst>
+          <a:solidFill>
+            <a:schemeClr val="phClr"/>
+          </a:solidFill>
+          <a:solidFill>
+            <a:schemeClr val="phClr">
+              <a:tint val="95000"/>
+              <a:satMod val="170000"/>
+            </a:schemeClr>
+          </a:solidFill>
+          <a:gradFill rotWithShape="1">
+            <a:gsLst>
+              <a:gs pos="0">
+                <a:schemeClr val="phClr">
+                  <a:tint val="93000"/>
+                  <a:satMod val="150000"/>
+                  <a:shade val="98000"/>
+                  <a:lumMod val="102000"/>
+                </a:schemeClr>
+              </a:gs>
+              <a:gs pos="50000">
+                <a:schemeClr val="phClr">
+                  <a:tint val="98000"/>
+                  <a:satMod val="130000"/>
+                  <a:shade val="90000"/>
+                  <a:lumMod val="103000"/>
+                </a:schemeClr>
+              </a:gs>
+              <a:gs pos="100000">
+                <a:schemeClr val="phClr">
+                  <a:shade val="63000"/>
+                  <a:satMod val="120000"/>
+                </a:schemeClr>
+              </a:gs>
+            </a:gsLst>
+            <a:lin ang="5400000" scaled="0"/>
+          </a:gradFill>
+        </a:bgFillStyleLst>
+      </a:fmtScheme>
+    </a:themeElements>
+  </a:theme>
+`;
+
+export default generateThemeXML;


### PR DESCRIPTION
## Why

Japanese fonts were not applied.

## How

- Add theme.xml for [fontScheme](https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.drawing.fontscheme?view=openxml-2.8.1#remarks)
  - `clrScheme` and `fmtScheme` are got from unzip with docx file

## Screenshot

<details>
<summary>image</summary>

- before
  - ![before](https://user-images.githubusercontent.com/4067007/125622727-9c6b37fe-e065-44a3-ae1c-350bc27f4c9f.png)
- after (add theme.xml)
  - ![after](https://user-images.githubusercontent.com/4067007/125622773-fb8844c8-f1dd-4480-892d-f0f5cf9c3e26.png)

</detail>