### PR TITLE
Fix the failure to export docx when the image path is not http.

### DIFF
--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -928,7 +928,9 @@ const buildParagraph = async (vNode, attributes, docxDocumentInstance) => {
             }
           } else {
             // eslint-disable-next-line no-useless-escape, prefer-destructuring
-            base64String = imageSource.match(/^data:([A-Za-z-+\/]+);base64,(.+)$/)[2];
+            base64String = imageSource.match(/^data:([A-Za-z-+\/]+);base64,(.+)$/)?.[2];
+            // eslint-disable-next-line no-continue
+            if (!base64String) continue;
           }
           const imageBuffer = Buffer.from(decodeURIComponent(base64String), 'base64');
           const imageProperties = sizeOf(imageBuffer);

--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -923,7 +923,7 @@ const buildParagraph = async (vNode, attributes, docxDocumentInstance) => {
             }
             base64String = await imageToBase64(imageSource).catch((error) => {
               // eslint-disable-next-line no-console
-              console.warning(`skipping image download and conversion due to ${error}`);
+              console.warning?.(`skipping image download and conversion due to ${error}`);
             });
 
             if (base64String && mimeTypes.lookup(imageSource)) {

--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -12,6 +12,7 @@ import { cloneDeep } from 'lodash';
 import imageToBase64 from 'image-to-base64';
 import mimeTypes from 'mime-types';
 import sizeOf from 'image-size';
+import { existsSync } from 'fs';
 
 import namespaces from '../namespaces';
 import {
@@ -912,8 +913,14 @@ const buildParagraph = async (vNode, attributes, docxDocumentInstance) => {
         const childVNode = vNode.children[index];
         if (childVNode.tagName === 'img') {
           let base64String;
-          const imageSource = childVNode.properties.src;
-          if (isValidUrl(imageSource)) {
+          let imageSource = childVNode.properties.src;
+          const isLocalFile = imageSource.startsWith('file:///');
+          if (isValidUrl(imageSource) || isLocalFile) {
+            if (isLocalFile) {
+              imageSource = imageSource.replace('file:///', '');
+              // eslint-disable-next-line no-continue
+              if (!existsSync(imageSource)) continue;
+            }
             base64String = await imageToBase64(imageSource).catch((error) => {
               // eslint-disable-next-line no-console
               console.warning(`skipping image download and conversion due to ${error}`);


### PR DESCRIPTION
I use your library to convert html to docx, it's great, but it's a little bad for image processing, this request does the following:
1. Support importing local images through file:/// schema
2. Prevent the exception that occurs when trying to read the base64 of the image (this causes the entire export process to be interrupted)