### PR TITLE
fix: add option to decode unicode in order to prevent crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ full fledged examples can be found under `example/`
     - `restart` <"continuous"|"newPage"|"newSection"> numbering restart strategy. Defaults to `continuous`.
   - `numbering` <?[Object]>
     - `defaultOrderedListStyleType` <?[String]> default ordered list style type. Defaults to `decimal`.
+  - `decodeUnicode` <?[Boolean]> flag to enable unicode decoding of header, body and footer. Defaults to `false`.
 - `footerHTMLString` <[String]> clean html string equivalent of footer. Defaults to `<p></p>` if footer flag is `true`.
 
 ### Returns

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@oozcitak/dom": "1.15.6",
         "@oozcitak/util": "8.3.4",
         "color-name": "^1.1.4",
+        "html-entities": "^2.3.3",
         "html-to-vdom": "^0.7.0",
         "image-size": "^1.0.0",
         "image-to-base64": "^2.2.0",
@@ -3385,6 +3386,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="
     },
     "node_modules/html-to-vdom": {
       "version": "0.7.0",
@@ -9370,6 +9376,11 @@
       "requires": {
         "lru-cache": "^6.0.0"
       }
+    },
+    "html-entities": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="
     },
     "html-to-vdom": {
       "version": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@oozcitak/util": "8.3.4",
     "@oozcitak/dom": "1.15.6",
     "color-name": "^1.1.4",
+    "html-entities": "^2.3.3",
     "html-to-vdom": "^0.7.0",
     "image-size": "^1.0.0",
     "image-to-base64": "^2.2.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,7 +9,7 @@ import * as meta from './package.json';
 
 export default {
   input: 'index.js',
-  external: ['color-name', 'html-to-vdom', 'jszip', 'virtual-dom', 'xmlbuilder2'],
+  external: ['color-name', 'html-to-vdom', 'jszip', 'virtual-dom', 'xmlbuilder2', 'html-entities'],
   plugins: [
     resolve(),
     json(),

--- a/src/constants.js
+++ b/src/constants.js
@@ -63,6 +63,7 @@ const defaultDocumentOptions = {
   numbering: {
     defaultOrderedListStyleType: 'decimal',
   },
+  decodeUnicode: false,
 };
 const defaultHTMLString = '<p></p>';
 const relsFolderName = '_rels';

--- a/src/html-to-docx.js
+++ b/src/html-to-docx.js
@@ -3,6 +3,7 @@ import VNode from 'virtual-dom/vnode/vnode';
 import VText from 'virtual-dom/vnode/vtext';
 // eslint-disable-next-line import/no-named-default
 import { default as HTMLToVDOM } from 'html-to-vdom';
+import { decode } from 'html-entities';
 
 import { relsXML } from './schemas';
 import DocxDocument from './docx-document';
@@ -125,6 +126,11 @@ async function addFilesToContainer(
   if (documentOptions.footer && !footerHTMLString) {
     // eslint-disable-next-line no-param-reassign
     footerHTMLString = defaultHTMLString;
+  }
+  if (documentOptions.decodeUnicode) {
+    headerHTMLString = decode(headerHTMLString); // eslint-disable-line no-param-reassign
+    htmlString = decode(htmlString); // eslint-disable-line no-param-reassign
+    footerHTMLString = decode(footerHTMLString); // eslint-disable-line no-param-reassign
   }
 
   const docxDocument = new DocxDocument({ zip, htmlString, ...documentOptions });


### PR DESCRIPTION
Solves https://github.com/privateOmega/html-to-docx/issues/130

As far as I've been able to test, it works fine. But please, do test it thoroughly!