### PR TITLE
fix: use image alt as description for images

### DIFF
--- a/src/helpers/render-document-file.js
+++ b/src/helpers/render-document-file.js
@@ -73,6 +73,7 @@ export const buildImage = async (docxDocumentInstance, vNode, maximumWidth = nul
         inlineOrAnchored: true,
         relationshipId: documentRelsId,
         ...response,
+        description: vNode.properties.alt,
         maximumWidth: maximumWidth || docxDocumentInstance.availableDocumentSpace,
         originalWidth: imageProperties.width,
         originalHeight: imageProperties.height,


### PR DESCRIPTION
I noticed that images in the examples do not seem to carry over their `alt` attributes to the corresponding `descr` attribute of images in the .docx file. This would add better accessbility for users when an `alt` has been provided on images.