### PR TITLE
feat: add used fonts to fonts table

### DIFF
--- a/example/example-node.js
+++ b/example/example-node.js
@@ -47,8 +47,10 @@ const htmlString =  `<!DOCTYPE html>
             <u>It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages,</u>and more recently with desktop publishing software
             <span style="color: hsl(0, 75%, 60%);"> like Aldus PageMaker </span>including versions of Lorem Ipsum.
             <span style="background-color: hsl(0, 75%, 60%);">Where does it come from? Contrary to popular belief, Lorem Ipsum is not simply random text.</span>
+            <span style="font-family:'Courier New', Courier, monospace;">Look at me, i'm a run in Courier New !</span>
             It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.
         </p>
+        <p style="font-family:'Courier New', Courier, monospace;">Look at me, i'm a paragraph in Courier New !</p>
         <blockquote>
             For 50 years, WWF has been protecting the future of nature. The world's leading conservation organization, WWF works in 100 countries and is supported by 1.2 million members in the United States and close to 5 million globally.
         </blockquote>

--- a/example/example-node.js
+++ b/example/example-node.js
@@ -50,7 +50,10 @@ const htmlString =  `<!DOCTYPE html>
             <span style="font-family:'Courier New', Courier, monospace;">Look at me, i'm a run in Courier New !</span>
             It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.
         </p>
-        <p style="font-family:'Courier New', Courier, monospace;">Look at me, i'm a paragraph in Courier New !</p>
+        <p style="font-family: 'Courier New', Courier, monospace;">Look at me, i'm a paragraph in Courier New !</p>
+        <p style="font-family: SerifTestFont, serif;">Look at me, i'm a paragraph in SerifTestFont</p>
+        <p style="font-family: SansTestFont, sans-serif;">Look at me, i'm a paragraph in SansTestFont</p>
+        <p style="font-family: MonoTestFont, monospace;">Look at me, i'm a paragraph in MonoTestFont</p>
         <blockquote>
             For 50 years, WWF has been protecting the future of nature. The world's leading conservation organization, WWF works in 100 countries and is supported by 1.2 million members in the United States and close to 5 million globally.
         </blockquote>

--- a/src/docx-document.js
+++ b/src/docx-document.js
@@ -34,6 +34,7 @@ import {
   defaultDocumentOptions,
 } from './constants';
 import ListStyleBuilder from './utils/list';
+import { fontFamilyToTableObject } from './utils/font-family-conversion';
 
 function generateContentTypesFragments(contentTypesXML, type, objects) {
   if (objects && Array.isArray(objects)) {
@@ -160,8 +161,9 @@ class DocxDocument {
     this.lastFooterId = 0;
     this.stylesObjects = [];
     this.numberingObjects = [];
+    this.fontTableObjects = [];
     this.relationshipFilename = documentFileName;
-    this.relationships = [{ fileName: documentFileName, lastRelsId: 4, rels: [] }];
+    this.relationships = [{ fileName: documentFileName, lastRelsId: 5, rels: [] }];
     this.mediaFiles = [];
     this.headerObjects = [];
     this.footerObjects = [];
@@ -262,9 +264,50 @@ class DocxDocument {
     );
   }
 
-  // eslint-disable-next-line class-methods-use-this
   generateFontTableXML() {
-    return generateXMLString(fontTableXMLString);
+    const fontTableXML = create({ encoding: 'UTF-8', standalone: true }, fontTableXMLString);
+    const fontNames = [
+      'Arial',
+      'Calibri',
+      'Calibri Light',
+      'Courier New',
+      'Symbol',
+      'Times New Roman',
+    ];
+    this.fontTableObjects.forEach(({ fontName, genericFontName }) => {
+      if (!fontNames.includes(fontName)) {
+        fontNames.push(fontName);
+        const fontFragment = fragment({
+          namespaceAlias: { w: namespaces.w },
+        })
+          .ele('@w', 'font')
+          .att('@w', 'name', fontName);
+
+        switch (genericFontName) {
+          case 'serif':
+            fontFragment.ele('@w', 'altName').att('@w', 'val', 'Times New Roman');
+            fontFragment.ele('@w', 'family').att('@w', 'val', 'roman');
+            fontFragment.ele('@w', 'pitch').att('@w', 'val', 'variable');
+            break;
+          case 'sans-serif':
+            fontFragment.ele('@w', 'altName').att('@w', 'val', 'Arial');
+            fontFragment.ele('@w', 'family').att('@w', 'val', 'swiss');
+            fontFragment.ele('@w', 'pitch').att('@w', 'val', 'variable');
+            break;
+          case 'monospace':
+            fontFragment.ele('@w', 'altName').att('@w', 'val', 'Courier New');
+            fontFragment.ele('@w', 'family').att('@w', 'val', 'modern');
+            fontFragment.ele('@w', 'pitch').att('@w', 'val', 'fixed');
+            break;
+          default:
+            break;
+        }
+
+        fontTableXML.root().import(fontFragment);
+      }
+    });
+
+    return fontTableXML.toString({ prettyPrint: true });
   }
 
   generateThemeXML() {
@@ -401,6 +444,12 @@ class DocxDocument {
     this.numberingObjects.push({ numberingId: this.lastNumberingId, type, properties });
 
     return this.lastNumberingId;
+  }
+
+  createFont(fontFamily) {
+    const fontTableObject = fontFamilyToTableObject(fontFamily, this.font);
+    this.fontTableObjects.push(fontTableObject);
+    return fontTableObject.fontName;
   }
 
   createMediaFile(base64String) {

--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -41,6 +41,7 @@ import {
   inchRegex,
   inchToTWIP,
 } from '../utils/unit-conversion';
+import { fontFamilyToFontName } from '../utils/font-family-conversion';
 // FIXME: remove the cyclic dependency
 // eslint-disable-next-line import/no-cycle
 import { buildImage, buildList } from './render-document-file';
@@ -327,6 +328,9 @@ const modifiedStyleAttributesBuilder = (vNode, attributes, options) => {
     if (vNode.properties.style['font-weight'] && vNode.properties.style['font-weight'] === 'bold') {
       modifiedAttributes.strong = vNode.properties.style['font-weight'];
     }
+    if (vNode.properties.style['font-family']) {
+      modifiedAttributes.font = fontFamilyToFontName(vNode.properties.style['font-family']);
+    }
     if (vNode.properties.style['font-size']) {
       modifiedAttributes.fontSize = fixupFontSize(vNode.properties.style['font-size']);
     }
@@ -404,6 +408,7 @@ const buildFormatting = (htmlTag, options) => {
     case 'highlightColor':
       return buildHighlight(options && options.color ? options.color : 'lightGray');
     case 'font':
+      return buildRunFontFragment(options.font);
     case 'pre':
       return buildRunFontFragment('Courier');
     case 'color':
@@ -429,8 +434,8 @@ const buildRunProperties = (attributes) => {
         options.color = attributes[key];
       }
 
-      if (key === 'fontSize') {
-        options.fontSize = attributes[key];
+      if (key === 'fontSize' || key === 'font') {
+        options[key] = attributes[key];
       }
 
       const formattingFragment = buildFormatting(key, options);

--- a/src/namespaces.js
+++ b/src/namespaces.js
@@ -18,6 +18,7 @@ const namespaces = {
   xsd: 'http://www.w3.org/2001/XMLSchema',
   xsi: 'http://www.w3.org/2001/XMLSchema-instance',
   numbering: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering',
+  fontTable: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/fontTable',
   hyperlinks: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink',
   images: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image',
   styles: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles',

--- a/src/schemas/document-rels.js
+++ b/src/schemas/document-rels.js
@@ -8,6 +8,7 @@ const documentRelsXML = `
     <Relationship Id="rId2" Type="${namespaces.styles}" Target="styles.xml"/>
     <Relationship Id="rId3" Type="${namespaces.settingsRelation}" Target="settings.xml"/>
     <Relationship Id="rId4" Type="${namespaces.webSettingsRelation}" Target="webSettings.xml"/>
+    <Relationship Id="rId5" Type="${namespaces.fontTable}" Target="fontTable.xml"/>
   </Relationships>
 `;
 

--- a/src/schemas/font-table.js
+++ b/src/schemas/font-table.js
@@ -1,5 +1,6 @@
 import namespaces from '../namespaces';
 
+// Font data available here: https://fossies.org/linux/pandoc/data/docx/word/fontTable.xml
 const fontTableXML = `
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 
@@ -7,12 +8,12 @@ const fontTableXML = `
       xmlns:r="${namespaces.r}"
       xmlns:w="${namespaces.w}"
       >
-        <w:font w:name="Symbol">
-            <w:panose1 w:val="05050102010706020507"/>
-            <w:charset w:val="02"/>
-            <w:family w:val="decorative"/>
+        <w:font w:name="Arial">
+            <w:panose1 w:val="020B0604020202020204"/>
+            <w:charset w:val="00"/>
+            <w:family w:val="auto"/>
             <w:pitch w:val="variable"/>
-            <w:sig w:usb0="00000000" w:usb1="10000000" w:usb2="00000000" w:usb3="00000000" w:csb0="80000000" w:csb1="00000000"/>
+            <w:sig w:usb0="00000003" w:usb1="00000000" w:usb2="00000000" w:usb3="00000000" w:csb0="00000001" w:csb1="00000000"/>
         </w:font>
         <w:font w:name="Calibri">
             <w:panose1 w:val="020F0502020204030204"/>
@@ -21,19 +22,33 @@ const fontTableXML = `
             <w:pitch w:val="variable"/>
             <w:sig w:usb0="E4002EFF" w:usb1="C000247B" w:usb2="00000009" w:usb3="00000000" w:csb0="000001FF" w:csb1="00000000"/>
         </w:font>
-        <w:font w:name="Times New Roman">
-            <w:panose1 w:val="02020603050405020304"/>
-            <w:charset w:val="00"/>
-            <w:family w:val="roman"/>
-            <w:pitch w:val="variable"/>
-            <w:sig w:usb0="E0002EFF" w:usb1="C000785B" w:usb2="00000009" w:usb3="00000000" w:csb0="000001FF" w:csb1="00000000"/>
-        </w:font>
         <w:font w:name="Calibri Light">
             <w:panose1 w:val="020F0302020204030204"/>
             <w:charset w:val="00"/>
             <w:family w:val="swiss"/>
             <w:pitch w:val="variable"/>
             <w:sig w:usb0="E4002EFF" w:usb1="C000247B" w:usb2="00000009" w:usb3="00000000" w:csb0="000001FF" w:csb1="00000000"/>
+        </w:font>
+        <w:font w:name="Courier New">
+            <w:panose1 w:val="02070309020205020404"/>
+            <w:charset w:val="00"/>
+            <w:family w:val="auto"/>
+            <w:pitch w:val="variable"/>
+            <w:sig w:usb0="00000003" w:usb1="00000000" w:usb2="00000000" w:usb3="00000000" w:csb0="00000001" w:csb1="00000000"/>
+        </w:font>
+        <w:font w:name="Symbol">
+            <w:panose1 w:val="05050102010706020507"/>
+            <w:charset w:val="02"/>
+            <w:family w:val="decorative"/>
+            <w:pitch w:val="variable"/>
+            <w:sig w:usb0="00000000" w:usb1="10000000" w:usb2="00000000" w:usb3="00000000" w:csb0="80000000" w:csb1="00000000"/>
+        </w:font>
+        <w:font w:name="Times New Roman">
+            <w:panose1 w:val="02020603050405020304"/>
+            <w:charset w:val="00"/>
+            <w:family w:val="roman"/>
+            <w:pitch w:val="variable"/>
+            <w:sig w:usb0="E0002EFF" w:usb1="C000785B" w:usb2="00000009" w:usb3="00000000" w:csb0="000001FF" w:csb1="00000000"/>
         </w:font>
     </w:fonts>
 `;

--- a/src/utils/font-family-conversion.js
+++ b/src/utils/font-family-conversion.js
@@ -1,12 +1,18 @@
 export const removeSimpleOrDoubleQuotes = /(["'])(.*?)\1/;
 
-export const fontFamilyToFontName = (fontFamilyString) => {
-  if (fontFamilyString) {
-    const firstFontName = fontFamilyString.split(',')[0];
-    if (removeSimpleOrDoubleQuotes.test(firstFontName)) {
-      return firstFontName.match(removeSimpleOrDoubleQuotes)[2];
-    }
-    return firstFontName;
-  }
-  return '';
+export const fontFamilyToTableObject = (fontFamilyString, fallbackFont) => {
+  const fontFamilyElements = fontFamilyString
+    ? fontFamilyString.split(',').map((fontName) => {
+        const trimmedFontName = fontName.trim();
+        if (removeSimpleOrDoubleQuotes.test(trimmedFontName)) {
+          return trimmedFontName.match(removeSimpleOrDoubleQuotes)[2];
+        }
+        return trimmedFontName;
+      })
+    : [fallbackFont];
+
+  return {
+    fontName: fontFamilyElements[0],
+    genericFontName: fontFamilyElements[fontFamilyElements.length - 1],
+  };
 };

--- a/src/utils/font-family-conversion.js
+++ b/src/utils/font-family-conversion.js
@@ -1,0 +1,12 @@
+export const removeSimpleOrDoubleQuotes = /(["'])(.*?)\1/;
+
+export const fontFamilyToFontName = (fontFamilyString) => {
+  if (fontFamilyString) {
+    const firstFontName = fontFamilyString.split(',')[0];
+    if (removeSimpleOrDoubleQuotes.test(firstFontName)) {
+      return firstFontName.match(removeSimpleOrDoubleQuotes)[2];
+    }
+    return firstFontName;
+  }
+  return '';
+};


### PR DESCRIPTION
This PR is following these one, but with the new commit cherry-picked onto develop:
https://github.com/privateOmega/html-to-docx/pull/113

Here is a copy/pasta of the previous description:

Hello,

### Goal of this PR
- extract the font information from the CSS `font-family`,
- insert the font in the text using `rFonts` in the `document.xml`
- register the used fonts in `fontTable.xml`, hinting the client about the font style if it doesn't have it installed.

### CSS to DOCX font mapping
Given the following CSS: `font-family: MyFont, Font1, Font2, serif`:
- `MyFont` will be the font name,
- `Font1, Font2` will be ignored,
- `serif` will be used to extract font properties.

### generic font names
The three main generic font names are translated to font properties:
#### serif
```
<w:font w:name="MyFont">
    <w:altName w:val="Times New Roman"/>
    <w:family w:val="roman"/>
    <w:pitch w:val="variable"/>
</w:font>
```
#### sans-serif
```
<w:font w:name="MyFont">
    <w:altName w:val="Arial"/>
    <w:family w:val="swiss"/>
    <w:pitch w:val="variable"/>
</w:font>
```
#### monospace
```
<w:font w:name="MyFont">
    <w:altName w:val="Courier New"/>
    <w:family w:val="modern"/>
    <w:pitch w:val="fixed"/>
</w:font>
```

Results really depends on the Word client:
- `Word Desktop` work as intended,
- `LibreOffice` ignore the `fontTable.xml` file, and find a font by itself
- `Word Online` ignore the `fontTable.xml` file, and find a font by itself but, since he is packed with a lot of fonts, find the wanted font *most of the time*.
