### PR TITLE
fix: update tblCellSpacing type

### DIFF
--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -1089,7 +1089,7 @@ const buildTableCellSpacing = (cellSpacing = 0) =>
   fragment({ namespaceAlias: { w: namespaces.w } })
     .ele('@w', 'tblCellSpacing')
     .att('@w', 'w', cellSpacing)
-    .att('@w', 'type', 'dxa')
+    .att('@w', 'type', 'auto')
     .up();
 
 const buildTableCellBorders = (tableCellBorder) => {


### PR DESCRIPTION
The table border disappears due to tblCellSpacing.




