### PR TITLE
Add repeatTableHeader argument to allow table headers to be repeated on subsequent pages

### DIFF
--- a/example/example-node.js
+++ b/example/example-node.js
@@ -212,6 +212,26 @@ const htmlString = `<!DOCTYPE html>
             </tr>
           </tbody>
         </table>
+        <ul>
+            <li style="margin-bottom:10px">
+                <span style="font-size:10pt"><span style="color:#e28743">I am a teacup <strong><span style="color:#595959">A strong teacup</span></strong></span></span>
+            </li>
+            <li style="margin-bottom:15px">
+                <span style="font-size:10pt"><span style="color:#4d4f53">I am another teacup <strong><span style="color:#2596be">A blue</span></strong> Teacup</span></span>
+            </li>
+            <li style="margin-bottom:20px">
+                <span style="font-size:15pt"><span style="color:#cc1177">Stonks only go up if you turn the chart sometimes</span></span>
+            </li>
+            <li style="margin-bottom:30px">
+                <span style="font-size:15pt"><span style="color:#cc1177">One small step for man</span></span>
+            </li>
+            <li>
+                <span style="font-size:30pt"><span style="color:#cc1177">One giant leap for mankind</span></span>
+            </li>
+            <li>
+                <span style="font-size:30pt"><span style="color:#cc1177">Never surrender, no mercy, and never give up!</span></span>
+            </li>
+        </ul>
     </body>
 </html>`;
 

--- a/example/example.js
+++ b/example/example.js
@@ -212,6 +212,26 @@ const htmlString = `<!DOCTYPE html>
             </tr>
           </tbody>
         </table>
+        <ul>
+            <li style="margin-bottom:10px">
+                <span style="font-size:10pt"><span style="color:#e28743">I am a teacup <strong><span style="color:#595959">A strong teacup</span></strong></span></span>
+            </li>
+            <li style="margin-bottom:15px">
+                <span style="font-size:10pt"><span style="color:#4d4f53">I am another teacup <strong><span style="color:#2596be">A blue</span></strong> Teacup</span></span>
+            </li>
+            <li style="margin-bottom:20px">
+                <span style="font-size:15pt"><span style="color:#cc1177">Stonks only go up if you turn the chart sometimes</span></span>
+            </li>
+            <li style="margin-bottom:30px">
+                <span style="font-size:15pt"><span style="color:#cc1177">One small step for man</span></span>
+            </li>
+            <li>
+                <span style="font-size:30pt"><span style="color:#cc1177">One giant leap for mankind</span></span>
+            </li>
+            <li>
+                <span style="font-size:30pt"><span style="color:#cc1177">Never surrender, no mercy, and never give up!</span></span>
+            </li>
+        </ul>
     </body>
 </html>`;
 

--- a/example/react-example/src/App.js
+++ b/example/react-example/src/App.js
@@ -209,6 +209,26 @@ const htmlString = `<!DOCTYPE html>
             </tr>
           </tbody>
         </table>
+        <ul>
+            <li style="margin-bottom:10px">
+                <span style="font-size:10pt"><span style="color:#e28743">I am a teacup <strong><span style="color:#595959">A strong teacup</span></strong></span></span>
+            </li>
+            <li style="margin-bottom:15px">
+                <span style="font-size:10pt"><span style="color:#4d4f53">I am another teacup <strong><span style="color:#2596be">A blue</span></strong> Teacup</span></span>
+            </li>
+            <li style="margin-bottom:20px">
+                <span style="font-size:15pt"><span style="color:#cc1177">Stonks only go up if you turn the chart sometimes</span></span>
+            </li>
+            <li style="margin-bottom:30px">
+                <span style="font-size:15pt"><span style="color:#cc1177">One small step for man</span></span>
+            </li>
+            <li>
+                <span style="font-size:30pt"><span style="color:#cc1177">One giant leap for mankind</span></span>
+            </li>
+            <li>
+                <span style="font-size:30pt"><span style="color:#cc1177">Never surrender, no mercy, and never give up!</span></span>
+            </li>
+        </ul>
     </body>
 </html>`;
 

--- a/src/helpers/render-document-file.js
+++ b/src/helpers/render-document-file.js
@@ -99,6 +99,8 @@ export const buildList = async (vNode, docxDocumentInstance, xmlFragment) => {
   while (vNodeObjects.length) {
     const tempVNodeObject = vNodeObjects.shift();
 
+    const parentVNodeProperties = tempVNodeObject.node.properties;
+
     if (
       isVText(tempVNodeObject.node) ||
       (isVNode(tempVNodeObject.node) && !['ul', 'ol', 'li'].includes(tempVNodeObject.node.tagName))
@@ -141,7 +143,19 @@ export const buildList = async (vNode, docxDocumentInstance, xmlFragment) => {
           } else {
             const paragraphVNode = new VNode(
               'p',
-              null,
+              isVNode(childVNode) && childVNode.properties && parentVNodeProperties
+                ? {
+                    attributes: {
+                      ...(parentVNodeProperties.attributes || {}),
+                      ...(childVNode.properties.attributes || {}),
+                    },
+                    style: {
+                      ...(parentVNodeProperties.style || {}),
+                      ...(childVNode.properties.style || {}),
+                    },
+                  }
+                : null, // copy properties for styling purposes
+
               // eslint-disable-next-line no-nested-ternary
               isVText(childVNode)
                 ? [childVNode]

--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -358,8 +358,8 @@ const modifiedStyleAttributesBuilder = (docxDocumentInstance, vNode, attributes,
       }
     }
 
-    // check to see if vNode tag is li and if so, check to see if there is a margin-bottom style. This usually happens in lists where we make a p node for each list item.
-    // and copy the margin-bottom (if applicable) to the p node. If there is a margin-bottom style, add it to the afterSpacing attribute
+    // list elements might have margin-bottom style and happens in list where a p node exist for each list item
+    // copy the margin-bottom (if applicable) to the afterSpacing attribute
     if (vNode.tagName === 'p' && vNode.properties.style['margin-bottom']) {
       modifiedAttributes.afterSpacing = fixupMargin(vNode.properties.style['margin-bottom']);
     }

--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -850,6 +850,18 @@ const buildParagraphProperties = (attributes) => {
   return paragraphPropertiesFragment;
 };
 
+const calculateAbsoluteValues = (attribute, originalAttributeInEMU) => {
+  if (attribute !== 'auto') {
+    if (pixelRegex.test(attribute)) {
+      return pixelToEMU(attribute.match(pixelRegex)[1]);
+    } else if (percentageRegex.test(attribute)) {
+      const percentageValue = attribute.match(percentageRegex)[1];
+      return Math.round((percentageValue / 100) * originalAttributeInEMU);
+    }
+  }
+  return originalAttributeInEMU;
+};
+
 const computeImageDimensions = (vNode, attributes) => {
   const { maximumWidth, originalWidth, originalHeight } = attributes;
   const aspectRatio = originalWidth / originalHeight;
@@ -873,32 +885,18 @@ const computeImageDimensions = (vNode, attributes) => {
 
     // style - width
     if (styleWidth) {
-      if (styleWidth !== 'auto') {
-        if (pixelRegex.test(styleWidth)) {
-          modifiedWidth = pixelToEMU(styleWidth.match(pixelRegex)[1]);
-        } else if (percentageRegex.test(styleWidth)) {
-          const percentageValue = styleWidth.match(percentageRegex)[1];
-
-          modifiedWidth = Math.round((percentageValue / 100) * originalWidthInEMU);
-        }
-      } else {
-        // eslint-disable-next-line no-lonely-if
-        if (styleHeight === 'auto') {
-          modifiedWidth = originalWidthInEMU;
-          modifiedHeight = originalHeightInEMU;
-        }
+      modifiedWidth = calculateAbsoluteValues(styleWidth, originalWidthInEMU);
+      if (styleWidth === 'auto' && styleHeight === 'auto') {
+        modifiedHeight = originalHeightInEMU;
       }
     }
 
     // style - height
     if (styleHeight) {
-      if (styleHeight !== 'auto') {
-        if (pixelRegex.test(styleHeight)) {
-          modifiedHeight = pixelToEMU(styleHeight.match(pixelRegex)[1]);
-        } else if (percentageRegex.test(styleHeight)) {
-          const percentageValue = styleHeight.match(percentageRegex)[1];
+      modifiedHeight = calculateAbsoluteValues(styleHeight, originalHeightInEMU);
 
-          modifiedHeight = Math.round((percentageValue / 100) * originalHeightInEMU);
+      if (styleHeight !== 'auto') {
+        if (percentageRegex.test(styleHeight)) {
           if (!modifiedWidth) {
             modifiedWidth = Math.round(modifiedHeight * aspectRatio);
           }
@@ -910,7 +908,6 @@ const computeImageDimensions = (vNode, attributes) => {
             modifiedHeight = Math.round(modifiedWidth / aspectRatio);
           }
         } else {
-          modifiedHeight = originalHeightInEMU;
           modifiedWidth = originalWidthInEMU;
         }
       }
@@ -918,38 +915,13 @@ const computeImageDimensions = (vNode, attributes) => {
 
     // style - max width
     if (styleMaxWidth) {
-      if (styleMaxWidth !== 'auto') {
-        if (pixelRegex.test(styleMaxWidth)) {
-          modifiedMaxWidth = pixelToEMU(styleMaxWidth.match(pixelRegex)[1]);
-        } else if (percentageRegex.test(styleMaxWidth)) {
-          const percentageValue = styleMaxWidth.match(percentageRegex)[1];
-
-          modifiedMaxWidth = Math.round((percentageValue / 100) * originalWidthInEMU);
-        }
-      } else {
-        modifiedMaxWidth = originalWidthInEMU;
-      }
+      modifiedMaxWidth = calculateAbsoluteValues(styleMaxWidth, originalWidthInEMU);
+      modifiedWidth = modifiedWidth > modifiedMaxWidth ? modifiedMaxWidth : modifiedWidth;
     }
 
     // style - max height
     if (styleMaxHeight) {
-      if (styleMaxHeight !== 'auto') {
-        if (pixelRegex.test(styleMaxHeight)) {
-          modifiedMaxHeight = pixelToEMU(styleMaxHeight.match(pixelRegex)[1]);
-        } else if (percentageRegex.test(styleMaxHeight)) {
-          const percentageValue = styleMaxHeight.match(percentageRegex)[1];
-
-          modifiedMaxHeight = Math.round((percentageValue / 100) * originalHeightInEMU);
-        }
-      } else {
-        modifiedMaxHeight = originalHeightInEMU;
-      }
-    }
-
-    if (modifiedMaxWidth) {
-      modifiedWidth = modifiedWidth > modifiedMaxWidth ? modifiedMaxWidth : modifiedWidth;
-    }
-    if (modifiedMaxHeight) {
+      modifiedMaxHeight = calculateAbsoluteValues(styleMaxHeight, originalHeightInEMU);
       modifiedHeight = modifiedHeight > modifiedMaxHeight ? modifiedMaxHeight : modifiedHeight;
     }
     if (modifiedWidth && !modifiedHeight) {

--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -862,16 +862,16 @@ const computeImageDimensions = (vNode, attributes) => {
   }
   let modifiedHeight;
   let modifiedWidth;
+  let modifiedMaxHeight;
+  let modifiedMaxWidth;
 
-  if (vNode.properties && vNode.properties.style) {
-    const styleWidth =
-      vNode.properties.style.width > vNode.properties.style['max-width']
-        ? vNode.properties.style['max-width']
-        : vNode.properties.style.width;
-    const styleHeight =
-      vNode.properties.style.height > vNode.properties.style['max-height']
-        ? vNode.properties.style['max-height']
-        : vNode.properties.style.height;
+  if (vNode?.properties?.style) {
+    const styleWidth = vNode.properties.style.width;
+    const styleHeight = vNode.properties.style.height;
+    const styleMaxWidth = vNode.properties.style['max-width'];
+    const styleMaxHeight = vNode.properties.style['max-height'];
+
+    // style - width
     if (styleWidth) {
       if (styleWidth !== 'auto') {
         if (pixelRegex.test(styleWidth)) {
@@ -883,18 +883,20 @@ const computeImageDimensions = (vNode, attributes) => {
         }
       } else {
         // eslint-disable-next-line no-lonely-if
-        if (styleHeight && styleHeight === 'auto') {
+        if (styleHeight === 'auto') {
           modifiedWidth = originalWidthInEMU;
           modifiedHeight = originalHeightInEMU;
         }
       }
     }
+
+    // style - height
     if (styleHeight) {
       if (styleHeight !== 'auto') {
         if (pixelRegex.test(styleHeight)) {
           modifiedHeight = pixelToEMU(styleHeight.match(pixelRegex)[1]);
         } else if (percentageRegex.test(styleHeight)) {
-          const percentageValue = styleWidth.match(percentageRegex)[1];
+          const percentageValue = styleHeight.match(percentageRegex)[1];
 
           modifiedHeight = Math.round((percentageValue / 100) * originalHeightInEMU);
           if (!modifiedWidth) {
@@ -912,6 +914,43 @@ const computeImageDimensions = (vNode, attributes) => {
           modifiedWidth = originalWidthInEMU;
         }
       }
+    }
+
+    // style - max width
+    if (styleMaxWidth) {
+      if (styleMaxWidth !== 'auto') {
+        if (pixelRegex.test(styleMaxWidth)) {
+          modifiedMaxWidth = pixelToEMU(styleMaxWidth.match(pixelRegex)[1]);
+        } else if (percentageRegex.test(styleMaxWidth)) {
+          const percentageValue = styleMaxWidth.match(percentageRegex)[1];
+
+          modifiedMaxWidth = Math.round((percentageValue / 100) * originalWidthInEMU);
+        }
+      } else {
+        modifiedMaxWidth = originalWidthInEMU;
+      }
+    }
+
+    // style - max height
+    if (styleMaxHeight) {
+      if (styleMaxHeight !== 'auto') {
+        if (pixelRegex.test(styleMaxHeight)) {
+          modifiedMaxHeight = pixelToEMU(styleMaxHeight.match(pixelRegex)[1]);
+        } else if (percentageRegex.test(styleMaxHeight)) {
+          const percentageValue = styleMaxHeight.match(percentageRegex)[1];
+
+          modifiedMaxHeight = Math.round((percentageValue / 100) * originalHeightInEMU);
+        }
+      } else {
+        modifiedMaxHeight = originalHeightInEMU;
+      }
+    }
+
+    if (modifiedMaxWidth) {
+      modifiedWidth = modifiedWidth > modifiedMaxWidth ? modifiedMaxWidth : modifiedWidth;
+    }
+    if (modifiedMaxHeight) {
+      modifiedHeight = modifiedHeight > modifiedMaxHeight ? modifiedMaxHeight : modifiedHeight;
     }
     if (modifiedWidth && !modifiedHeight) {
       modifiedHeight = Math.round(modifiedWidth / aspectRatio);

--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -357,6 +357,13 @@ const modifiedStyleAttributesBuilder = (docxDocumentInstance, vNode, attributes,
         modifiedAttributes.indentation = indentation;
       }
     }
+
+    // check to see if vNode tag is li and if so, check to see if there is a margin-bottom style. This usually happens in lists where we make a p node for each list item.
+    // and copy the margin-bottom (if applicable) to the p node. If there is a margin-bottom style, add it to the afterSpacing attribute
+    if (vNode.tagName === 'p' && vNode.properties.style['margin-bottom']) {
+      modifiedAttributes.afterSpacing = fixupMargin(vNode.properties.style['margin-bottom']);
+    }
+
     if (vNode.properties.style.display) {
       modifiedAttributes.display = vNode.properties.style.display;
     }
@@ -707,13 +714,13 @@ const buildNumberingInstances = () =>
 const buildSpacing = (lineSpacing, beforeSpacing, afterSpacing) => {
   const spacingFragment = fragment({ namespaceAlias: { w: namespaces.w } }).ele('@w', 'spacing');
 
-  if (lineSpacing) {
+  if (typeof lineSpacing === 'number' && lineSpacing >= 0) {
     spacingFragment.att('@w', 'line', lineSpacing);
   }
-  if (beforeSpacing) {
+  if (typeof beforeSpacing === 'number' && beforeSpacing >= 0) {
     spacingFragment.att('@w', 'before', beforeSpacing);
   }
-  if (afterSpacing) {
+  if (typeof afterSpacing === 'number' && afterSpacing >= 0) {
     spacingFragment.att('@w', 'after', afterSpacing);
   }
 

--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -916,13 +916,21 @@ const computeImageDimensions = (vNode, attributes) => {
     // style - max width
     if (styleMaxWidth) {
       modifiedMaxWidth = calculateAbsoluteValues(styleMaxWidth, originalWidthInEMU);
-      modifiedWidth = modifiedWidth > modifiedMaxWidth ? modifiedMaxWidth : modifiedWidth;
+      if (modifiedWidth) {
+        modifiedWidth = modifiedWidth > modifiedMaxWidth ? modifiedMaxWidth : modifiedWidth;
+      } else {
+        modifiedWidth = modifiedMaxWidth;
+      }
     }
 
     // style - max height
     if (styleMaxHeight) {
       modifiedMaxHeight = calculateAbsoluteValues(styleMaxHeight, originalHeightInEMU);
-      modifiedHeight = modifiedHeight > modifiedMaxHeight ? modifiedMaxHeight : modifiedHeight;
+      if (modifiedHeight) {
+        modifiedHeight = modifiedHeight > modifiedMaxHeight ? modifiedMaxHeight : modifiedHeight;
+      } else {
+        modifiedHeight = modifiedMaxHeight;
+      }
     }
     if (modifiedWidth && !modifiedHeight) {
       modifiedHeight = Math.round(modifiedWidth / aspectRatio);

--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -864,29 +864,37 @@ const computeImageDimensions = (vNode, attributes) => {
   let modifiedWidth;
 
   if (vNode.properties && vNode.properties.style) {
-    if (vNode.properties.style.width) {
-      if (vNode.properties.style.width !== 'auto') {
-        if (pixelRegex.test(vNode.properties.style.width)) {
-          modifiedWidth = pixelToEMU(vNode.properties.style.width.match(pixelRegex)[1]);
-        } else if (percentageRegex.test(vNode.properties.style.width)) {
-          const percentageValue = vNode.properties.style.width.match(percentageRegex)[1];
+    const styleWidth =
+      vNode.properties.style.width > vNode.properties.style['max-width']
+        ? vNode.properties.style['max-width']
+        : vNode.properties.style.width;
+    const styleHeight =
+      vNode.properties.style.height > vNode.properties.style['max-height']
+        ? vNode.properties.style['max-height']
+        : vNode.properties.style.height;
+    if (styleWidth) {
+      if (styleWidth !== 'auto') {
+        if (pixelRegex.test(styleWidth)) {
+          modifiedWidth = pixelToEMU(styleWidth.match(pixelRegex)[1]);
+        } else if (percentageRegex.test(styleWidth)) {
+          const percentageValue = styleWidth.match(percentageRegex)[1];
 
           modifiedWidth = Math.round((percentageValue / 100) * originalWidthInEMU);
         }
       } else {
         // eslint-disable-next-line no-lonely-if
-        if (vNode.properties.style.height && vNode.properties.style.height === 'auto') {
+        if (styleHeight && styleHeight === 'auto') {
           modifiedWidth = originalWidthInEMU;
           modifiedHeight = originalHeightInEMU;
         }
       }
     }
-    if (vNode.properties.style.height) {
-      if (vNode.properties.style.height !== 'auto') {
-        if (pixelRegex.test(vNode.properties.style.height)) {
-          modifiedHeight = pixelToEMU(vNode.properties.style.height.match(pixelRegex)[1]);
-        } else if (percentageRegex.test(vNode.properties.style.height)) {
-          const percentageValue = vNode.properties.style.width.match(percentageRegex)[1];
+    if (styleHeight) {
+      if (styleHeight !== 'auto') {
+        if (pixelRegex.test(styleHeight)) {
+          modifiedHeight = pixelToEMU(styleHeight.match(pixelRegex)[1]);
+        } else if (percentageRegex.test(styleHeight)) {
+          const percentageValue = styleWidth.match(percentageRegex)[1];
 
           modifiedHeight = Math.round((percentageValue / 100) * originalHeightInEMU);
           if (!modifiedWidth) {


### PR DESCRIPTION
If the tblHeader property is added to a table, then the header row of the table is repeated across every page (if the table spans multiple pages).

You can turn this on by setting the table.row.repeatTableHeader argument to true.