### PR TITLE
feature: Add repeatTableHeader argument to allow table headers to be repeated on subsequent pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ full fledged examples can be found under `example/`
   - `table` <?[Object]>
     - `row` <?[Object]>
       - `cantSplit` <?[Boolean]> flag to allow table row to split across pages. Defaults to `false`.
+      - `repeatTableHeader` <?[Boolean]> flag to allow table headers to be repeated across mulitple pages. Defaults to `false`.
   - `pageNumber` <?[Boolean]> flag to enable page number in footer. Defaults to `false`. Page number works only if footer flag is set as `true`.
   - `skipFirstHeaderFooter` <?[Boolean]> flag to skip first page header and footer. Defaults to `false`.
   - `lineNumber` <?[Boolean]> flag to enable line numbering. Defaults to `false`.

--- a/src/helpers/xml-builder.js
+++ b/src/helpers/xml-builder.js
@@ -1465,6 +1465,16 @@ const buildTableRowProperties = (attributes) => {
             delete attributes.rowCantSplit;
           }
           break;
+        case 'repeatTableHeader':
+          if (attributes.repeatTableHeader) {
+            const headerFragment = fragment({ namespaceAlias: { w: namespaces.w } })
+              .ele('@w', 'tblHeader')
+              .up();
+            tableRowPropertiesFragment.import(headerFragment);
+            // eslint-disable-next-line no-param-reassign
+            delete attributes.repeatTableHeader;
+          }
+          break;
       }
     });
   }


### PR DESCRIPTION
If the tblHeader property is added to a table, then the header row of the table is repeated across every page (if the table spans multiple pages).

You can turn this on by setting the table.row.repeatTableHeader argument to true.